### PR TITLE
Fix for children elements

### DIFF
--- a/flashy.js
+++ b/flashy.js
@@ -237,7 +237,7 @@ class FlashMessages extends HTMLElement {
             if (elem.nextElementSibling) {
                 triggerAnimation(200, 'moveup', elem.nextElementSibling);
             }
-            if (elem.nextElementSibling.nextElementSibling) {
+            if (elem.nextElementSibling !== null && elem.nextElementSibling.nextElementSibling) {
                 triggerAnimation(
                     200,
                     'moveup',
@@ -364,7 +364,7 @@ class FlashMessages extends HTMLElement {
         this.style.bottom = `${this.shadowRootObj.children[0].clientHeight -
             this.clientHeight +
             20}px`;
-        this.shadowRootObj.children[0].children[0].style.height = `${
+        this.shadowRootObj.children[0].style.height = `${
             this.shadowRootObj.children[0].clientHeight
         }px`;
     }


### PR DESCRIPTION
I deleted what I think is a typo since  line 367 try to access .children[0].children[0] this bit was giving out an error in the console.
Line 228 I added a test to prevent an error appearing when you close a flash message before its expiracy time when multiple flash messages were issued.